### PR TITLE
Tokio-core interop

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ license = "MIT"
 [dependencies]
 mio = "0.6"
 futures = "0.1"
+tokio-core = "0.1"
 lazy_static = "0.1"
 splay_tree = "0.2"
 num_cpus = "1"

--- a/src/executor/mod.rs
+++ b/src/executor/mod.rs
@@ -14,6 +14,8 @@ use sync::oneshot::{Monitor, MonitorError};
 mod in_place;
 mod thread_pool;
 
+mod tokio;
+
 /// The `Executor` trait allows for spawning and executing fibers.
 pub trait Executor: Sized {
     /// The handle type of the executor.

--- a/src/executor/tokio.rs
+++ b/src/executor/tokio.rs
@@ -1,0 +1,32 @@
+use Spawn;
+use Executor;
+use tokio_core::reactor::{Core, Handle, Remote};
+
+use futures::{BoxFuture, Future};
+
+impl Spawn for Remote {
+    fn spawn_boxed(&self, f: BoxFuture<(), ()>) {
+        Spawn::spawn(self, f)
+    }
+
+    fn spawn<F>(&self, fiber: F)
+        where F: Future<Item = (), Error = ()> + Send + 'static
+    {
+        Remote::spawn(self, |h| ::futures::future::ok(h.spawn(fiber)))
+    }
+}
+
+
+impl Executor for Core {
+    type Handle = Remote;
+
+    fn handle(&self) -> Self::Handle {
+        self.remote()
+    }
+
+    fn run_once(&mut self) -> ::std::io::Result<()> {
+        self.turn(None);
+        Ok(())
+    }
+}
+

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -189,6 +189,8 @@ extern crate handy_async;
 #[macro_use]
 extern crate lazy_static;
 
+extern crate tokio_core;
+
 macro_rules! assert_some {
     ($e:expr) => {
         $e.expect(&format!("[{}:{}] {:?} must be a Some(..)",


### PR DESCRIPTION
This provides implementations of Spawn/Executor for Remote/Core
respectively.