### PR TITLE
Apply up-to-date formatter/lint

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ extern crate fibers;
 extern crate futures;
 
 use fibers::{Spawn, Executor, ThreadPoolExecutor};
-use futures::{Future, BoxFuture};
+use futures::Future;
 
 fn main() {
     // Creates an executor instance.
@@ -122,14 +122,14 @@ fn main() {
     assert_eq!(answer, Ok(55));
 }
 
-fn fibonacci<H: Spawn + Clone>(n: usize, handle: H) -> BoxFuture<usize, ()> {
+fn fibonacci<H: Spawn + Clone>(n: usize, handle: H) -> Box<Future<Item=usize, Error=()> + Send> {
     if n < 2 {
-        futures::finished(n).boxed()
+        Box::new(futures::finished(n))
     } else {
         /// Spawns a new fiber per recursive call.
         let f0 = handle.spawn_monitor(fibonacci(n - 1, handle.clone()));
         let f1 = handle.spawn_monitor(fibonacci(n - 2, handle.clone()));
-        f0.join(f1).map(|(a0, a1)| a0 + a1).map_err(|_| ()).boxed()
+        Box::new(f0.join(f1).map(|(a0, a1)| a0 + a1).map_err(|_| ()))
     }
 }
 ```

--- a/examples/fibonacci.rs
+++ b/examples/fibonacci.rs
@@ -6,16 +6,18 @@ extern crate fibers;
 extern crate futures;
 
 use clap::{App, Arg};
-use fibers::{Spawn, Executor, ThreadPoolExecutor};
-use futures::{Future, BoxFuture};
+use fibers::{Executor, Spawn, ThreadPoolExecutor};
+use futures::{BoxFuture, Future};
 
 fn main() {
     let matches = App::new("fibonacci")
         .arg(Arg::with_name("INPUT_NUMBER").index(1).required(true))
         .get_matches();
-    let input_number = matches.value_of("INPUT_NUMBER").unwrap().parse().expect(
-        "Invalid number",
-    );
+    let input_number = matches
+        .value_of("INPUT_NUMBER")
+        .unwrap()
+        .parse()
+        .expect("Invalid number");
 
     let mut executor = ThreadPoolExecutor::new().unwrap();
     let future = fibonacci(input_number, executor.handle());

--- a/examples/http_echo_srv.rs
+++ b/examples/http_echo_srv.rs
@@ -47,11 +47,11 @@ fn main() {
                                     // Read header
                                     let mut headers = [httparse::EMPTY_HEADER; 16];
                                     let mut req = httparse::Request::new(&mut headers);
-                                    let status = req.parse(&buf).map_err(into_io_error)?;
+                                    let status = req.parse(buf).map_err(into_io_error)?;
                                     if status.is_partial() {
                                         Ok(None)
                                     } else {
-                                        let content_len = get_content_length(&req.headers)?;
+                                        let content_len = get_content_length(req.headers)?;
                                         let content_offset = status.unwrap();
                                         Ok(Some((content_offset, content_len)))
                                     }

--- a/examples/tcp_example.rs
+++ b/examples/tcp_example.rs
@@ -5,11 +5,11 @@ extern crate fibers;
 extern crate futures;
 extern crate handy_async;
 
-use fibers::{Spawn, Executor, ThreadPoolExecutor};
+use fibers::{Executor, Spawn, ThreadPoolExecutor};
 use fibers::net::{TcpListener, TcpStream};
 use fibers::sync::oneshot;
 use futures::{Future, Stream};
-use handy_async::io::{AsyncWrite, AsyncRead};
+use handy_async::io::{AsyncRead, AsyncWrite};
 
 fn main() {
     let mut executor = ThreadPoolExecutor::new().unwrap();
@@ -17,43 +17,41 @@ fn main() {
     let (addr_tx, addr_rx) = oneshot::channel();
 
     // Spawns TCP listener
-    executor.spawn(TcpListener::bind("127.0.0.1:0".parse().unwrap())
-                       .and_then(|listener| {
-        let addr = listener.local_addr().unwrap();
-        println!("# Start listening: {}", addr);
-        addr_tx.send(addr).unwrap();
-        listener
-            .incoming()
-            .for_each(move |(client, addr)| {
-                println!("# Accepted: {}", addr);
-                handle.spawn(client
-                                 .map_err(|e| panic!("{:?}", e))
-                                 .and_then(|client| {
-                                               client
-                                                   .async_write_all(b"Hello World!")
-                                                   .map_err(|e| panic!("{:?}", e))
-                                                   .map(|_| ())
-                                           }));
-                Ok(())
+    executor.spawn(
+        TcpListener::bind("127.0.0.1:0".parse().unwrap())
+            .and_then(|listener| {
+                let addr = listener.local_addr().unwrap();
+                println!("# Start listening: {}", addr);
+                addr_tx.send(addr).unwrap();
+                listener.incoming().for_each(move |(client, addr)| {
+                    println!("# Accepted: {}", addr);
+                    handle.spawn(client.map_err(|e| panic!("{:?}", e)).and_then(|client| {
+                        client
+                            .async_write_all(b"Hello World!")
+                            .map_err(|e| panic!("{:?}", e))
+                            .map(|_| ())
+                    }));
+                    Ok(())
+                })
             })
-    })
-                       .map_err(|e| panic!("{:?}", e)));
+            .map_err(|e| panic!("{:?}", e)),
+    );
 
     // Spawns TCP client
-    let mut monitor = executor.spawn_monitor(addr_rx
-                                                 .map_err(|e| panic!("{:?}", e))
-                                                 .and_then(|server_addr| {
-        TcpStream::connect(server_addr).and_then(move |stream| {
-            println!("# Connected: {}", server_addr);
-            stream
-                .async_read(vec![0; 32])
-                .map(|(_, mut buf, size)| {
-                         buf.truncate(size);
-                         assert_eq!(buf, b"Hello World!");
-                     })
-                .map_err(|e| panic!("{:?}", e))
-        })
-    }));
+    let mut monitor = executor.spawn_monitor(addr_rx.map_err(|e| panic!("{:?}", e)).and_then(
+        |server_addr| {
+            TcpStream::connect(server_addr).and_then(move |stream| {
+                println!("# Connected: {}", server_addr);
+                stream
+                    .async_read(vec![0; 32])
+                    .map(|(_, mut buf, size)| {
+                        buf.truncate(size);
+                        assert_eq!(buf, b"Hello World!");
+                    })
+                    .map_err(|e| panic!("{:?}", e))
+            })
+        },
+    ));
 
     // Runs until the TCP client exits
     while monitor.poll().unwrap().is_not_ready() {

--- a/examples/udp_example.rs
+++ b/examples/udp_example.rs
@@ -1,8 +1,8 @@
 // Copyright (c) 2016 DWANGO Co., Ltd. All Rights Reserved.
 // See the LICENSE file at the top-level directory of this distribution.
 
-extern crate futures;
 extern crate fibers;
+extern crate futures;
 
 use fibers::{Executor, InPlaceExecutor, Spawn};
 use fibers::net::UdpSocket;
@@ -14,32 +14,36 @@ fn main() {
     let (addr_tx, addr_rx) = oneshot::channel();
 
     // Spawns receiver
-    let mut monitor = executor.spawn_monitor(UdpSocket::bind("127.0.0.1:0".parse().unwrap())
-                                                 .and_then(|socket| {
-        addr_tx.send(socket.local_addr().unwrap()).unwrap();
-        socket.recv_from(vec![0; 32]).map_err(|(_, _, e)| e)
-    })
-                                                 .and_then(|(_, mut buf, len, addr)| {
-                                                               println!("# Recv from: {}", addr);
-                                                               buf.truncate(len);
-                                                               assert_eq!(buf, b"hello world");
-                                                               Ok(())
-                                                           }));
+    let mut monitor = executor.spawn_monitor(
+        UdpSocket::bind("127.0.0.1:0".parse().unwrap())
+            .and_then(|socket| {
+                addr_tx.send(socket.local_addr().unwrap()).unwrap();
+                socket.recv_from(vec![0; 32]).map_err(|(_, _, e)| e)
+            })
+            .and_then(|(_, mut buf, len, addr)| {
+                println!("# Recv from: {}", addr);
+                buf.truncate(len);
+                assert_eq!(buf, b"hello world");
+                Ok(())
+            }),
+    );
 
     // Spawns sender
-    executor.spawn(addr_rx
-                       .map_err(|e| panic!("{:?}", e))
-                       .and_then(|receiver_addr| {
-        UdpSocket::bind("127.0.0.1:0".parse().unwrap())
-            .and_then(move |socket| {
-                          println!("# Send to: {}", receiver_addr);
-                          socket
-                              .send_to(b"hello world", receiver_addr)
-                              .map_err(|e| panic!("{:?}", e))
-                      })
+    executor.spawn(
+        addr_rx
             .map_err(|e| panic!("{:?}", e))
-            .map(|_| ())
-    }));
+            .and_then(|receiver_addr| {
+                UdpSocket::bind("127.0.0.1:0".parse().unwrap())
+                    .and_then(move |socket| {
+                        println!("# Send to: {}", receiver_addr);
+                        socket
+                            .send_to(b"hello world", receiver_addr)
+                            .map_err(|e| panic!("{:?}", e))
+                    })
+                    .map_err(|e| panic!("{:?}", e))
+                    .map(|_| ())
+            }),
+    );
 
     // Runs until the receiver fiber exits.
     while monitor.poll().unwrap().is_not_ready() {

--- a/src/collections.rs
+++ b/src/collections.rs
@@ -19,7 +19,9 @@ where
 {
     /// Makes new heap instance.
     pub fn new() -> Self {
-        HeapMap { inner: SplayMap::new() }
+        HeapMap {
+            inner: SplayMap::new(),
+        }
     }
 
     /// Pushes the entry in the heap, if an entry which has the `key`

--- a/src/executor/in_place.rs
+++ b/src/executor/in_place.rs
@@ -62,7 +62,9 @@ impl InPlaceExecutor {
 impl Executor for InPlaceExecutor {
     type Handle = InPlaceExecutorHandle;
     fn handle(&self) -> Self::Handle {
-        InPlaceExecutorHandle { scheduler: self.scheduler.handle() }
+        InPlaceExecutorHandle {
+            scheduler: self.scheduler.handle(),
+        }
     }
     fn run_once(&mut self) -> io::Result<()> {
         self.scheduler.run_once(false);

--- a/src/executor/thread_pool.rs
+++ b/src/executor/thread_pool.rs
@@ -112,7 +112,7 @@ impl Executor for ThreadPoolExecutor {
         }
         self.steps = self.steps.wrapping_add(1);
         let i = self.steps % self.pool.schedulers.len();
-        if let Err(_) = self.pool.links[i].poll() {
+        if self.pool.links[i].poll().is_err() {
             Err(io::Error::new(
                 io::ErrorKind::Other,
                 format!("The {}-th scheduler thread is aborted", i),

--- a/src/fiber/mod.rs
+++ b/src/fiber/mod.rs
@@ -8,14 +8,14 @@
 use std::fmt;
 use std::sync::Arc;
 use std::sync::atomic::{self, AtomicUsize};
-use futures::{self, Async, Future, BoxFuture, IntoFuture};
+use futures::{self, Async, BoxFuture, Future, IntoFuture};
 use futures::future::Either;
 use handy_async::future::FutureExt;
 
 pub use self::schedule::{Scheduler, SchedulerHandle, SchedulerId};
 pub use self::schedule::{with_current_context, yield_poll, Context};
 
-use sync::oneshot::{self, Monitor, Link};
+use sync::oneshot::{self, Link, Monitor};
 
 mod schedule;
 

--- a/src/fiber/schedule.rs
+++ b/src/fiber/schedule.rs
@@ -5,7 +5,7 @@ use std::sync::atomic;
 use std::collections::{HashMap, VecDeque};
 use std::sync::mpsc as std_mpsc;
 use std::cell::RefCell;
-use futures::{Async, BoxFuture, Poll};
+use futures::{Async, Future, Poll};
 
 use fiber::{self, Task};
 use io::poll;
@@ -209,7 +209,7 @@ impl SchedulerHandle {
     }
 }
 impl Spawn for SchedulerHandle {
-    fn spawn_boxed(&self, fiber: BoxFuture<(), ()>) {
+    fn spawn_boxed(&self, fiber: Box<Future<Item = (), Error = ()> + Send>) {
         let _ = self.request_tx.send(Request::Spawn(Task(fiber)));
     }
 }
@@ -301,7 +301,7 @@ impl<'a> Context<'a> {
 /// # }
 /// ```
 pub fn yield_poll<T, E>() -> Poll<T, E> {
-    with_current_context(|mut context| context.fiber.yield_once());
+    with_current_context(|context| context.fiber.yield_once());
     Ok(Async::NotReady)
 }
 

--- a/src/fiber/schedule.rs
+++ b/src/fiber/schedule.rs
@@ -5,11 +5,11 @@ use std::sync::atomic;
 use std::collections::{HashMap, VecDeque};
 use std::sync::mpsc as std_mpsc;
 use std::cell::RefCell;
-use futures::{BoxFuture, Poll, Async};
+use futures::{Async, BoxFuture, Poll};
 
 use fiber::{self, Task};
 use io::poll;
-use super::{Spawn, FiberState};
+use super::{FiberState, Spawn};
 
 static mut NEXT_SCHEDULER_ID: atomic::AtomicUsize = atomic::ATOMIC_USIZE_INIT;
 
@@ -51,7 +51,9 @@ impl Scheduler {
     pub fn new(poller: poll::PollerHandle) -> Self {
         let (request_tx, request_rx) = std_mpsc::channel();
         Scheduler {
-            scheduler_id: unsafe { NEXT_SCHEDULER_ID.fetch_add(1, atomic::Ordering::SeqCst) },
+            scheduler_id: unsafe {
+                NEXT_SCHEDULER_ID.fetch_add(1, atomic::Ordering::SeqCst)
+            },
             next_fiber_id: 0,
             fibers: HashMap::new(),
             run_queue: VecDeque::new(),
@@ -78,7 +80,9 @@ impl Scheduler {
 
     /// Returns a handle of this scheduler.
     pub fn handle(&self) -> SchedulerHandle {
-        SchedulerHandle { request_tx: self.request_tx.clone() }
+        SchedulerHandle {
+            request_tx: self.request_tx.clone(),
+        }
     }
 
     /// Runs one unit of works.
@@ -123,10 +127,8 @@ impl Scheduler {
     }
     fn spawn_fiber(&mut self, task: Task) {
         let fiber_id = self.next_fiber_id();
-        self.fibers.insert(
-            fiber_id,
-            fiber::FiberState::new(fiber_id, task),
-        );
+        self.fibers
+            .insert(fiber_id, fiber::FiberState::new(fiber_id, task));
         self.schedule(fiber_id);
     }
     fn run_fiber(&mut self, fiber_id: fiber::FiberId) {
@@ -134,10 +136,10 @@ impl Scheduler {
         let is_runnable = {
             CURRENT_CONTEXT.with(|context| {
                 let mut context = context.borrow_mut();
-                if context.scheduler.as_ref().map_or(
-                    true,
-                    |s| s.id != self.scheduler_id,
-                )
+                if context
+                    .scheduler
+                    .as_ref()
+                    .map_or(true, |s| s.id != self.scheduler_id)
                 {
                     context.switch(self);
                 }
@@ -155,7 +157,9 @@ impl Scheduler {
             });
             let fiber = assert_some!(self.fibers.get_mut(&fiber_id));
             finished = fiber.run_once();
-            CURRENT_CONTEXT.with(|context| { context.borrow_mut().fiber = None; });
+            CURRENT_CONTEXT.with(|context| {
+                context.borrow_mut().fiber = None;
+            });
             fiber.is_runnable()
         };
         if finished {
@@ -217,7 +221,6 @@ pub struct CurrentScheduler {
     pub poller: poll::PollerHandle,
 }
 
-
 /// Calls `f` with the current execution context.
 ///
 /// If this function is called on the outside of a fiber, it will ignores `f` and returns `None`.
@@ -225,9 +228,7 @@ pub fn with_current_context<F, T>(f: F) -> Option<T>
 where
     F: FnOnce(Context) -> T,
 {
-    CURRENT_CONTEXT.with(|inner_context| {
-        inner_context.borrow_mut().as_context().map(f)
-    })
+    CURRENT_CONTEXT.with(|inner_context| inner_context.borrow_mut().as_context().map(f))
 }
 
 /// The execution context of the currently running fiber.
@@ -244,10 +245,8 @@ impl<'a> Context<'a> {
 
     /// Parks the current fiber.
     pub fn park(&mut self) -> super::Unpark {
-        self.fiber.park(
-            self.scheduler.id,
-            self.scheduler.handle.clone(),
-        )
+        self.fiber
+            .park(self.scheduler.id, self.scheduler.handle.clone())
     }
 
     /// Returns the I/O event poller for this context.

--- a/src/fiber/schedule.rs
+++ b/src/fiber/schedule.rs
@@ -51,9 +51,7 @@ impl Scheduler {
     pub fn new(poller: poll::PollerHandle) -> Self {
         let (request_tx, request_rx) = std_mpsc::channel();
         Scheduler {
-            scheduler_id: unsafe {
-                NEXT_SCHEDULER_ID.fetch_add(1, atomic::Ordering::SeqCst)
-            },
+            scheduler_id: unsafe { NEXT_SCHEDULER_ID.fetch_add(1, atomic::Ordering::SeqCst) },
             next_fiber_id: 0,
             fibers: HashMap::new(),
             run_queue: VecDeque::new(),

--- a/src/io/poll/mod.rs
+++ b/src/io/poll/mod.rs
@@ -14,10 +14,10 @@ use std::ops;
 use std::sync::Arc;
 use mio;
 
-pub use self::poller::{Poller, PollerHandle, EventedHandle};
+pub use self::poller::{EventedHandle, Poller, PollerHandle};
 pub use self::poller::{Register, DEFAULT_EVENTS_CAPACITY};
 
-use sync_atomic::{AtomicCell, AtomicBorrowMut};
+use sync_atomic::{AtomicBorrowMut, AtomicCell};
 
 pub(crate) mod poller;
 

--- a/src/io/poll/mod.rs
+++ b/src/io/poll/mod.rs
@@ -42,7 +42,7 @@ where
 }
 impl<T> Clone for SharableEvented<T> {
     fn clone(&self) -> Self {
-        SharableEvented(self.0.clone())
+        SharableEvented(Arc::clone(&self.0))
     }
 }
 impl<T> mio::Evented for SharableEvented<T>

--- a/src/io/poll/poller.rs
+++ b/src/io/poll/poller.rs
@@ -160,7 +160,7 @@ impl Poller {
     pub fn handle(&self) -> PollerHandle {
         PollerHandle {
             request_tx: self.request_tx.clone(),
-            next_timeout_id: self.next_timeout_id.clone(),
+            next_timeout_id: Arc::clone(&self.next_timeout_id),
             is_alive: true,
         }
     }
@@ -251,7 +251,10 @@ impl PollerHandle {
             let handle = EventedHandle::new(evented, request_tx, token);
             let _ = tx.send(handle);
         });
-        let reply = RegisterReplyFn(Box::new(move |token| (reply.take().unwrap())(token)));
+        let reply = RegisterReplyFn(Box::new(move |token| {
+            let reply = reply.take().unwrap();
+            reply(token)
+        }));
         if self.request_tx
             .send(Request::Register(box_evented, reply))
             .is_err()
@@ -265,7 +268,7 @@ impl PollerHandle {
         let (tx, rx) = oneshot::channel();
         let expiry_time = time::Instant::now() + delay_from_now;
         let timeout_id = self.next_timeout_id.fetch_add(1, atomic::Ordering::SeqCst);
-        let request = Request::SetTimeout(timeout_id, expiry_time.clone(), tx);
+        let request = Request::SetTimeout(timeout_id, expiry_time, tx);
         let _ = self.request_tx.send(request);
         Timeout {
             cancel: Some(CancelTimeout {
@@ -375,9 +378,9 @@ impl<T> Clone for EventedHandle<T> {
     fn clone(&self) -> Self {
         self.shared_count.fetch_add(1, atomic::Ordering::SeqCst);
         EventedHandle {
-            token: self.token.clone(),
+            token: self.token,
             request_tx: self.request_tx.clone(),
-            shared_count: self.shared_count.clone(),
+            shared_count: Arc::clone(&self.shared_count),
             inner: self.inner.clone(),
         }
     }

--- a/src/io/stdio.rs
+++ b/src/io/stdio.rs
@@ -33,7 +33,7 @@ pub fn stdin() -> Stdin {
             let mut locked_stdin = stdin.lock();
 
             // # (2) Readability Check Phase
-            break_if_err!(locked_stdin.read(&mut []));
+            let _ = break_if_err!(locked_stdin.read(&mut []));
             break_if_err!(res_tx.send(Ok(Vec::new())));
 
             // # (3) Read Phase

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -185,12 +185,12 @@
 //! ```
 #![warn(missing_docs)]
 
-extern crate mio;
 extern crate futures;
-extern crate splay_tree;
-extern crate num_cpus;
 extern crate handy_async;
+extern crate mio;
 extern crate nbchan;
+extern crate num_cpus;
+extern crate splay_tree;
 
 macro_rules! assert_some {
     ($e:expr) => {
@@ -210,7 +210,7 @@ macro_rules! assert_ok {
 pub use self::executor::{Executor, InPlaceExecutor, ThreadPoolExecutor};
 
 #[doc(inline)]
-pub use self::fiber::{Spawn, BoxSpawn};
+pub use self::fiber::{BoxSpawn, Spawn};
 
 pub mod io;
 pub mod net;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,7 +55,7 @@
 //! [sync](sync/index.html), [io](io/index.html), [time](time/index.html) modules for more details).
 //!
 //! The main concern of this library is "how to execute fibers".
-//! So it is preferred to use external crates (e.g., [handy_async][handy_async])
+//! So it is preferred to use external crates (e.g., [`handy_async`][handy_async])
 //! to describe "how to represent asynchronous tasks".
 //!
 //! [handy_async]: https://github.com/sile/handy_async

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -78,16 +78,16 @@
 //! # extern crate fibers;
 //! # extern crate futures;
 //! use fibers::{Spawn, Executor, ThreadPoolExecutor};
-//! use futures::{Future, BoxFuture};
+//! use futures::Future;
 //!
-//! fn fibonacci<H: Spawn + Clone>(n: usize, handle: H) -> BoxFuture<usize, ()> {
+//! fn fibonacci<H: Spawn + Clone>(n: usize, handle: H) -> Box<Future<Item=usize, Error=()> + Send> {
 //!     if n < 2 {
-//!         futures::finished(n).boxed()
+//!         Box::new(futures::finished(n))
 //!     } else {
-//!         /// Spawns a new fiber per recursive call.
+//!         // Spawns a new fiber per recursive call.
 //!         let f0 = handle.spawn_monitor(fibonacci(n - 1, handle.clone()));
 //!         let f1 = handle.spawn_monitor(fibonacci(n - 2, handle.clone()));
-//!         f0.join(f1).map(|(a0, a1)| a0 + a1).map_err(|_| ()).boxed()
+//!         Box::new(f0.join(f1).map(|(a0, a1)| a0 + a1).map_err(|_| ()))
 //!     }
 //! }
 //!
@@ -195,13 +195,6 @@ extern crate splay_tree;
 macro_rules! assert_some {
     ($e:expr) => {
         $e.expect(&format!("[{}:{}] {:?} must be a Some(..)",
-                           file!(), line!(), stringify!($e)))
-    }
-}
-
-macro_rules! assert_ok {
-    ($e:expr) => {
-        $e.expect(&format!("[{}:{}] {:?} must be a Ok(..)",
                            file!(), line!(), stringify!($e)))
     }
 }

--- a/src/net/mod.rs
+++ b/src/net/mod.rs
@@ -23,7 +23,7 @@ use std::fmt;
 use std::error;
 use std::net::SocketAddr;
 use mio;
-use futures::{Poll, Async, Future};
+use futures::{Async, Future, Poll};
 
 pub use self::udp::UdpSocket;
 pub use self::tcp::{TcpListener, TcpStream};
@@ -33,8 +33,8 @@ use io::poll::{EventedHandle, Register};
 
 pub mod futures {
     //! Implementations of `futures::Future` trait.
-    pub use super::udp::{UdpSocketBind, SendTo, RecvFrom};
-    pub use super::tcp::{TcpListenerBind, Connect, Connected};
+    pub use super::udp::{RecvFrom, SendTo, UdpSocketBind};
+    pub use super::tcp::{Connect, Connected, TcpListenerBind};
 }
 pub mod streams {
     //! Implementations of `futures::Stream` trait.
@@ -60,9 +60,8 @@ where
         match mem::replace(self, Bind::Polled) {
             Bind::Bind(addr, bind) => {
                 let socket = bind(&addr)?;
-                let register = assert_some!(fiber::with_current_context(
-                    |mut c| c.poller().register(socket),
-                ));
+                let register = assert_some!(fiber::with_current_context(|mut c| c.poller()
+                    .register(socket),));
                 *self = Bind::Registering(register);
                 self.poll()
             }

--- a/src/net/tcp.rs
+++ b/src/net/tcp.rs
@@ -1,6 +1,7 @@
 // Copyright (c) 2016 DWANGO Co., Ltd. All Rights Reserved.
 // See the LICENSE file at the top-level directory of this distribution.
 
+use std::fmt;
 use std::io;
 use std::mem;
 use std::net::SocketAddr;
@@ -60,7 +61,6 @@ use super::{into_io_error, Bind};
 /// println!("# Succeeded");
 /// # }
 /// ```
-#[derive(Debug)]
 pub struct TcpListener {
     handle: EventedHandle<MioTcpListener>,
     monitor: Option<Monitor<(), io::Error>>,
@@ -96,6 +96,16 @@ impl TcpListener {
         F: FnOnce(&MioTcpListener) -> T,
     {
         f(&*self.handle.inner())
+    }
+}
+impl fmt::Debug for TcpListener {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "TcpListener {{ ")?;
+        if let Ok(addr) = self.local_addr() {
+            write!(f, "local_addr:{:?}, ", addr)?;
+        }
+        write!(f, ".. }}")?;
+        Ok(())
     }
 }
 
@@ -249,7 +259,6 @@ impl Future for Connected {
 /// println!("# Succeeded");
 /// # }
 /// ```
-#[derive(Debug)]
 pub struct TcpStream {
     handle: EventedHandle<MioTcpStream>,
     read_monitor: Option<Monitor<(), io::Error>>,
@@ -362,6 +371,19 @@ impl io::Write for TcpStream {
     }
     fn flush(&mut self) -> io::Result<()> {
         self.operate(Interest::Write, |inner| inner.flush())
+    }
+}
+impl fmt::Debug for TcpStream {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "TcpStream {{ ")?;
+        if let Ok(addr) = self.local_addr() {
+            write!(f, "local_addr:{:?}, ", addr)?;
+        }
+        if let Ok(addr) = self.peer_addr() {
+            write!(f, "peer_addr:{:?}, ", addr)?;
+        }
+        write!(f, ".. }}")?;
+        Ok(())
     }
 }
 

--- a/src/net/tcp.rs
+++ b/src/net/tcp.rs
@@ -200,7 +200,7 @@ impl Future for Connected {
 ///
 /// To handle read/write operations over TCP streams in
 /// [futures](https://github.com/alexcrichton/futures-rs) style,
-/// it is preferred to use external crate like [handy_async](https://github.com/sile/handy_async).
+/// it is preferred to use external crate like [`handy_async`](https://github.com/sile/handy_async).
 ///
 /// # Examples
 ///

--- a/src/net/udp.rs
+++ b/src/net/udp.rs
@@ -1,6 +1,7 @@
 // Copyright (c) 2016 DWANGO Co., Ltd. All Rights Reserved.
 // See the LICENSE file at the top-level directory of this distribution.
 
+use std::fmt;
 use std::io;
 use std::net::SocketAddr;
 use futures::{Async, Future, Poll};
@@ -55,7 +56,7 @@ use super::{into_io_error, Bind};
 /// }
 /// # }
 /// ```
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct UdpSocket {
     handle: EventedHandle<MioUdpSocket>,
 }
@@ -104,6 +105,16 @@ impl UdpSocket {
         F: FnOnce(&MioUdpSocket) -> T,
     {
         f(&*self.handle.inner())
+    }
+}
+impl fmt::Debug for UdpSocket {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "UdpSocket {{ ")?;
+        if let Ok(addr) = self.local_addr() {
+            write!(f, "local_addr:{:?}, ", addr)?;
+        }
+        write!(f, ".. }}")?;
+        Ok(())
     }
 }
 

--- a/src/net/udp.rs
+++ b/src/net/udp.rs
@@ -3,10 +3,10 @@
 
 use std::io;
 use std::net::SocketAddr;
-use futures::{Poll, Async, Future};
+use futures::{Async, Future, Poll};
 use mio::net::UdpSocket as MioUdpSocket;
 
-use io::poll::{Interest, EventedHandle};
+use io::poll::{EventedHandle, Interest};
 use sync::oneshot::Monitor;
 use super::{into_io_error, Bind};
 
@@ -152,10 +152,11 @@ impl<B: AsRef<[u8]>> Future for SendTo<B> {
                     Ok(Async::Ready(())) => {}
                 }
             } else {
-                let result = state.socket.handle.inner().send_to(
-                    state.buf.as_ref(),
-                    &state.target,
-                );
+                let result = state
+                    .socket
+                    .handle
+                    .inner()
+                    .send_to(state.buf.as_ref(), &state.target);
                 match result {
                     Err(e) => {
                         if e.kind() == io::ErrorKind::WouldBlock {

--- a/src/sync/mod.rs
+++ b/src/sync/mod.rs
@@ -16,7 +16,9 @@ struct Notifier {
 }
 impl Notifier {
     pub fn new() -> Self {
-        Notifier { unpark: Arc::new(AtomicCell::new(None)) }
+        Notifier {
+            unpark: Arc::new(AtomicCell::new(None)),
+        }
     }
     pub fn await(&mut self) {
         loop {

--- a/src/sync/mpsc.rs
+++ b/src/sync/mpsc.rs
@@ -62,7 +62,7 @@
 //! If a corresponding sender finds there is a waiting receiver,
 //! it will resume (reschedule) the fiber, after sending a message.
 use std::sync::mpsc as std_mpsc;
-use futures::{Poll, Async, Stream, Sink, StartSend, AsyncSink};
+use futures::{Async, AsyncSink, Poll, Sink, StartSend, Stream};
 
 use super::Notifier;
 

--- a/src/sync/mpsc.rs
+++ b/src/sync/mpsc.rs
@@ -61,6 +61,7 @@
 //! an object shared with the senders.
 //! If a corresponding sender finds there is a waiting receiver,
 //! it will resume (reschedule) the fiber, after sending a message.
+use std::fmt;
 use std::sync::mpsc as std_mpsc;
 use futures::{Async, AsyncSink, Poll, Sink, StartSend, Stream};
 
@@ -145,7 +146,6 @@ pub fn sync_channel<T>(bound: usize) -> (SyncSender<T>, Receiver<T>) {
 /// This receving stream will never fail.
 ///
 /// This structure can be used on both inside and outside of a fiber.
-#[derive(Debug)]
 pub struct Receiver<T> {
     inner: std_mpsc::Receiver<T>,
     notifier: Notifier,
@@ -174,11 +174,15 @@ impl<T> Drop for Receiver<T> {
         self.notifier.notify();
     }
 }
+impl<T> fmt::Debug for Receiver<T> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "Receiver {{ .. }}")
+    }
+}
 
 /// The sending-half of a asynchronous channel.
 ///
 /// This structure can be used on both inside and outside of a fiber.
-#[derive(Debug)]
 pub struct Sender<T> {
     inner: std_mpsc::Sender<T>,
     notifier: Notifier,
@@ -206,11 +210,15 @@ impl<T> Drop for Sender<T> {
         self.notifier.notify();
     }
 }
+impl<T> fmt::Debug for Sender<T> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "Sender {{ .. }}")
+    }
+}
 
 /// The sending-half of a synchronous channel.
 ///
 /// This structure can be used on both inside and outside of a fiber.
-#[derive(Debug)]
 pub struct SyncSender<T> {
     inner: std_mpsc::SyncSender<T>,
     notifier: Notifier,
@@ -243,5 +251,10 @@ impl<T> Clone for SyncSender<T> {
 impl<T> Drop for SyncSender<T> {
     fn drop(&mut self) {
         self.notifier.notify();
+    }
+}
+impl<T> fmt::Debug for SyncSender<T> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "SyncSender {{ .. }}")
     }
 }

--- a/src/sync/oneshot.rs
+++ b/src/sync/oneshot.rs
@@ -83,7 +83,6 @@ pub fn channel<T>() -> (Sender<T>, Receiver<T>) {
 /// The sending-half of an asynchronous oneshot channel.
 ///
 /// This structure can be used on both inside and outside of a fiber.
-#[derive(Debug)]
 pub struct Sender<T> {
     inner: Option<nbchan::oneshot::Sender<T>>,
     notifier: Notifier,
@@ -102,11 +101,15 @@ impl<T> Drop for Sender<T> {
         self.notifier.notify();
     }
 }
+impl<T> fmt::Debug for Sender<T> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "Sender {{ .. }}")
+    }
+}
 
 /// The receiving-half of a oneshot channel.
 ///
 /// This structure can be used on both inside and outside of a fiber.
-#[derive(Debug)]
 pub struct Receiver<T> {
     inner: nbchan::oneshot::Receiver<T>,
     notifier: Notifier,
@@ -130,6 +133,11 @@ impl<T> Future for Receiver<T> {
 impl<T> Drop for Receiver<T> {
     fn drop(&mut self) {
         self.notifier.notify();
+    }
+}
+impl<T> fmt::Debug for Receiver<T> {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "Receiver {{ .. }}")
     }
 }
 

--- a/src/sync/oneshot.rs
+++ b/src/sync/oneshot.rs
@@ -18,7 +18,7 @@
 use std::fmt;
 use std::error;
 use std::sync::mpsc::{RecvError, SendError};
-use futures::{Poll, Async, Future};
+use futures::{Async, Future, Poll};
 use nbchan;
 
 use super::Notifier;

--- a/src/sync/oneshot.rs
+++ b/src/sync/oneshot.rs
@@ -345,11 +345,14 @@ impl<E: fmt::Display> fmt::Display for MonitorError<E> {
 }
 
 /// Creates a oneshot channel for bidirectional monitoring.
-pub fn link<T0, E0, T1, E1>() -> (Link<T0, E0, T1, E1>, Link<T1, E1, T0, E0>) {
+pub fn link<T0, E0, T1, E1>() -> LinkPair<T0, E0, T1, E1> {
     let (tx0, rx0) = monitor();
     let (tx1, rx1) = monitor();
     (Link { tx: tx0, rx: rx1 }, Link { tx: tx1, rx: rx0 })
 }
+
+/// Bidirectional link pair.
+pub type LinkPair<T0, E0, T1, E1> = (Link<T0, E0, T1, E1>, Link<T1, E1, T0, E0>);
 
 /// The half of a link channel.
 ///

--- a/src/sync_atomic.rs
+++ b/src/sync_atomic.rs
@@ -13,7 +13,9 @@ pub struct AtomicCell<T> {
 impl<T> AtomicCell<T> {
     pub fn new(inner: T) -> Self {
         let boxed = Box::new(inner);
-        AtomicCell { inner: AtomicPtr::new(Box::into_raw(boxed)) }
+        AtomicCell {
+            inner: AtomicPtr::new(Box::into_raw(boxed)),
+        }
     }
     pub fn try_borrow_mut(&self) -> Option<AtomicBorrowMut<T>> {
         let old = self.inner.swap(ptr::null_mut(), atomic::Ordering::SeqCst);

--- a/src/sync_atomic.rs
+++ b/src/sync_atomic.rs
@@ -19,7 +19,7 @@ impl<T> AtomicCell<T> {
     }
     pub fn try_borrow_mut(&self) -> Option<AtomicBorrowMut<T>> {
         let old = self.inner.swap(ptr::null_mut(), atomic::Ordering::SeqCst);
-        if old == ptr::null_mut() {
+        if old.is_null() {
             None
         } else {
             let inner = unsafe { Box::from_raw(old) };

--- a/src/time.rs
+++ b/src/time.rs
@@ -6,7 +6,7 @@ pub mod timer {
     //! Timer
     use std::time;
     use std::sync::mpsc as std_mpsc;
-    use futures::{Future, Poll, Async};
+    use futures::{Async, Future, Poll};
 
     use io::poll;
     use fiber::{self, Context};
@@ -95,7 +95,7 @@ pub mod timer {
     #[cfg(test)]
     mod test {
         use std::time::Duration;
-        use futures::{self, Future, Async};
+        use futures::{self, Async, Future};
         use super::*;
 
         #[test]


### PR DESCRIPTION
This PR applies up-to-date formatter and lint(clippy).
And the deprecated features in `futures` crate are removed.