### PR TITLE
Use `nbchan` crate for non-blocking channels

### DIFF
--- a/src/time.rs
+++ b/src/time.rs
@@ -5,7 +5,7 @@
 pub mod timer {
     //! Timer
     use std::time;
-    use std::sync::mpsc as std_mpsc;
+    use std::sync::mpsc::RecvError;
     use futures::{Async, Future, Poll};
 
     use io::poll;
@@ -67,7 +67,7 @@ pub mod timer {
     }
     impl Future for Timeout {
         type Item = ();
-        type Error = std_mpsc::RecvError;
+        type Error = RecvError;
         fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
             if let Some(ref mut inner) = self.inner {
                 inner.poll()


### PR DESCRIPTION
This PR replaces the internal implementation of the mpsc channels from [the standard channels](https://doc.rust-lang.org/std/sync/mpsc/index.html) to [nbchan](https://crates.io/crates/nbchan).
Because [nbchan] is specialized in non-blocking communications, so it is more suitable for use with `fibers`.

[nbchan]: https://crates.io/crates/nbchan