### PR TITLE
Version 0.1.10

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fibers"
-version = "0.1.9"
+version = "0.1.10"
 authors = ["Takeru Ohta <takeru_ohta@dwango.co.jp>"]
 description = "A Rust library to execute a number of lightweight asynchronous tasks (a.k.a, fibers) based on futures and mio"
 homepage = "https://github.com/dwango/fibers-rs"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,9 +14,9 @@ mio = "0.6"
 futures = "0.1"
 splay_tree = "0.2"
 num_cpus = "1"
-handy_async = "0.2"
 nbchan = "0.1"
 
 [dev-dependencies]
 clap = "2"
+handy_async = "0.2"
 httparse = "1"

--- a/examples/http_echo_srv.rs
+++ b/examples/http_echo_srv.rs
@@ -7,12 +7,12 @@ extern crate futures;
 extern crate handy_async;
 extern crate httparse;
 
-use std::io;
 use clap::{App, Arg};
+use fibers::{Executor, Spawn, ThreadPoolExecutor};
+use futures::{Future, Stream};
 use handy_async::io::{ReadFrom, WriteInto};
 use handy_async::pattern::{self, Branch, Pattern, Window};
-use futures::{Future, Stream};
-use fibers::{Executor, Spawn, ThreadPoolExecutor};
+use std::io;
 
 fn main() {
     let matches = App::new("http_echo_srv")

--- a/examples/tcp_echo_srv.rs
+++ b/examples/tcp_echo_srv.rs
@@ -6,12 +6,12 @@ extern crate fibers;
 extern crate futures;
 extern crate handy_async;
 
-use std::io;
 use clap::{App, Arg};
 use fibers::{Executor, Spawn, ThreadPoolExecutor};
 use futures::{Future, Stream};
 use handy_async::io::{AsyncWrite, ReadFrom};
 use handy_async::pattern::AllowPartial;
+use std::io;
 
 fn main() {
     let matches = App::new("tcp_echo_srv")

--- a/examples/tcp_example.rs
+++ b/examples/tcp_example.rs
@@ -5,9 +5,9 @@ extern crate fibers;
 extern crate futures;
 extern crate handy_async;
 
-use fibers::{Executor, Spawn, ThreadPoolExecutor};
 use fibers::net::{TcpListener, TcpStream};
 use fibers::sync::oneshot;
+use fibers::{Executor, Spawn, ThreadPoolExecutor};
 use futures::{Future, Stream};
 use handy_async::io::{AsyncRead, AsyncWrite};
 

--- a/examples/udp_example.rs
+++ b/examples/udp_example.rs
@@ -4,9 +4,9 @@
 extern crate fibers;
 extern crate futures;
 
-use fibers::{Executor, InPlaceExecutor, Spawn};
 use fibers::net::UdpSocket;
 use fibers::sync::oneshot;
+use fibers::{Executor, InPlaceExecutor, Spawn};
 use futures::Future;
 
 fn main() {

--- a/src/executor/in_place.rs
+++ b/src/executor/in_place.rs
@@ -1,13 +1,13 @@
 // Copyright (c) 2016 DWANGO Co., Ltd. All Rights Reserved.
 // See the LICENSE file at the top-level directory of this distribution.
 
+use futures::Future;
 use std::io;
 use std::time;
-use futures::Future;
 
+use super::Executor;
 use fiber::{self, Spawn};
 use io::poll;
-use super::Executor;
 
 /// An executor that executes spawned fibers and I/O event polling on current thread.
 ///

--- a/src/executor/in_place.rs
+++ b/src/executor/in_place.rs
@@ -55,7 +55,7 @@ impl InPlaceExecutor {
         let poller = poll::Poller::new()?;
         Ok(InPlaceExecutor {
             scheduler: fiber::Scheduler::new(poller.handle()),
-            poller: poller,
+            poller,
         })
     }
 }

--- a/src/executor/mod.rs
+++ b/src/executor/mod.rs
@@ -2,8 +2,8 @@
 // See the LICENSE file at the top-level directory of this distribution.
 
 //! The `Executor` trait and its implementations.
-use std::io;
 use futures::{Async, Future};
+use std::io;
 
 pub use self::in_place::{InPlaceExecutor, InPlaceExecutorHandle};
 pub use self::thread_pool::{ThreadPoolExecutor, ThreadPoolExecutorHandle};

--- a/src/executor/thread_pool.rs
+++ b/src/executor/thread_pool.rs
@@ -1,19 +1,19 @@
 // Copyright (c) 2016 DWANGO Co., Ltd. All Rights Reserved.
 // See the LICENSE file at the top-level directory of this distribution.
 
-use std::io;
-use std::time;
-use std::thread;
-use std::sync::mpsc::TryRecvError;
 use futures::{Async, Future};
 use nbchan::mpsc as nb_mpsc;
 use num_cpus;
+use std::io;
+use std::sync::mpsc::TryRecvError;
+use std::thread;
+use std::time;
 
+use super::Executor;
+use fiber::Task;
 use fiber::{self, Spawn};
 use io::poll;
 use sync::oneshot::{self, Link};
-use fiber::Task;
-use super::Executor;
 
 /// An executor that executes spawned fibers on pooled threads.
 ///

--- a/src/executor/thread_pool.rs
+++ b/src/executor/thread_pool.rs
@@ -84,7 +84,7 @@ impl ThreadPoolExecutor {
         let (tx, rx) = nb_mpsc::channel();
         Ok(ThreadPoolExecutor {
             pool: schedulers,
-            pollers: pollers,
+            pollers,
             spawn_tx: tx,
             spawn_rx: rx,
             round: 0,
@@ -164,10 +164,7 @@ impl PollerPool {
                 }
             });
         }
-        Ok(PollerPool {
-            pollers: pollers,
-            links: links,
-        })
+        Ok(PollerPool { pollers, links })
     }
 }
 
@@ -191,9 +188,6 @@ impl SchedulerPool {
                 }
             });
         }
-        SchedulerPool {
-            schedulers: schedulers,
-            links: links,
-        }
+        SchedulerPool { schedulers, links }
     }
 }

--- a/src/fiber/mod.rs
+++ b/src/fiber/mod.rs
@@ -57,7 +57,10 @@ pub trait Spawn {
         E: Send + 'static,
     {
         let (monitored, monitor) = oneshot::monitor();
-        self.spawn(f.then(move |r| Ok(monitored.exit(r))));
+        self.spawn(f.then(move |r| {
+            monitored.exit(r);
+            Ok(())
+        }));
         monitor
     }
 
@@ -153,8 +156,8 @@ struct FiberState {
 impl FiberState {
     pub fn new(fiber_id: FiberId, task: Task) -> Self {
         FiberState {
-            fiber_id: fiber_id,
-            task: task,
+            fiber_id,
+            task,
             parks: 0,
             unparks: Arc::new(AtomicUsize::new(0)),
             in_run_queue: false,
@@ -183,8 +186,8 @@ impl FiberState {
         Unpark {
             fiber_id: self.fiber_id,
             unparks: Arc::clone(&self.unparks),
-            scheduler_id: scheduler_id,
-            scheduler: scheduler,
+            scheduler_id,
+            scheduler,
         }
     }
     pub fn yield_once(&mut self) {

--- a/src/fiber/mod.rs
+++ b/src/fiber/mod.rs
@@ -5,15 +5,15 @@
 //!
 //! Those are mainly exported for developers.
 //! So, usual users do not need to be conscious.
+use futures::future::Either;
+use futures::{self, Async, Future, IntoFuture};
+use handy_async::future::FutureExt;
 use std::fmt;
 use std::sync::Arc;
 use std::sync::atomic::{self, AtomicUsize};
-use futures::{self, Async, Future, IntoFuture};
-use futures::future::Either;
-use handy_async::future::FutureExt;
 
-pub use self::schedule::{Scheduler, SchedulerHandle, SchedulerId};
 pub use self::schedule::{with_current_context, yield_poll, Context};
+pub use self::schedule::{Scheduler, SchedulerHandle, SchedulerId};
 
 use sync::oneshot::{self, Link, Monitor};
 

--- a/src/fiber/schedule.rs
+++ b/src/fiber/schedule.rs
@@ -55,9 +55,9 @@ impl Scheduler {
             next_fiber_id: 0,
             fibers: HashMap::new(),
             run_queue: VecDeque::new(),
-            request_tx: request_tx,
-            request_rx: request_rx,
-            poller: poller,
+            request_tx,
+            request_rx,
+            poller,
         }
     }
 
@@ -327,10 +327,7 @@ impl InnerContext {
         if let Some(scheduler) = self.scheduler.as_mut() {
             if let Some(fiber) = self.fiber {
                 let fiber = unsafe { &mut *fiber };
-                return Some(Context {
-                    scheduler: scheduler,
-                    fiber: fiber,
-                });
+                return Some(Context { scheduler, fiber });
             }
         }
         None

--- a/src/fiber/schedule.rs
+++ b/src/fiber/schedule.rs
@@ -1,15 +1,15 @@
 // Copyright (c) 2016 DWANGO Co., Ltd. All Rights Reserved.
 // See the LICENSE file at the top-level directory of this distribution.
 
-use std::sync::atomic;
-use std::collections::{HashMap, VecDeque};
-use std::sync::mpsc as std_mpsc;
-use std::cell::RefCell;
 use futures::{Async, Future, Poll};
+use std::cell::RefCell;
+use std::collections::{HashMap, VecDeque};
+use std::sync::atomic;
+use std::sync::mpsc as std_mpsc;
 
+use super::{FiberState, Spawn};
 use fiber::{self, Task};
 use io::poll;
-use super::{FiberState, Spawn};
 
 static mut NEXT_SCHEDULER_ID: atomic::AtomicUsize = atomic::ATOMIC_USIZE_INIT;
 

--- a/src/io/poll/mod.rs
+++ b/src/io/poll/mod.rs
@@ -9,13 +9,13 @@
 //! # Implementation Details
 //!
 //! This module is a wrapper of the [mio](https://github.com/carllerche/mio) crate.
+use mio;
 use std::io;
 use std::ops;
 use std::sync::Arc;
-use mio;
 
-pub use self::poller::{EventedHandle, Poller, PollerHandle};
 pub use self::poller::{Register, DEFAULT_EVENTS_CAPACITY};
+pub use self::poller::{EventedHandle, Poller, PollerHandle};
 
 use sync_atomic::{AtomicBorrowMut, AtomicCell};
 

--- a/src/io/poll/poller.rs
+++ b/src/io/poll/poller.rs
@@ -40,7 +40,7 @@ impl Registrant {
     pub fn new(evented: BoxEvented) -> Self {
         Registrant {
             is_first: true,
-            evented: evented,
+            evented,
             read_waitings: Vec::new(),
             write_waitings: Vec::new(),
         }
@@ -87,7 +87,7 @@ impl Poller {
         let poll = mio::Poll::new()?;
         let (tx, rx) = nb_mpsc::channel();
         Ok(Poller {
-            poll: poll,
+            poll,
             events: MioEvents(mio::Events::with_capacity(capacity)),
             request_tx: tx,
             request_rx: rx,
@@ -262,7 +262,7 @@ impl PollerHandle {
         {
             self.is_alive = false;
         }
-        Register { rx: rx }
+        Register { rx }
     }
 
     fn set_timeout(&self, delay_from_now: time::Duration) -> Timeout {
@@ -273,11 +273,11 @@ impl PollerHandle {
         let _ = self.request_tx.send(request);
         Timeout {
             cancel: Some(CancelTimeout {
-                timeout_id: timeout_id,
-                expiry_time: expiry_time,
+                timeout_id,
+                expiry_time,
                 request_tx: self.request_tx.clone(),
             }),
-            rx: rx,
+            rx,
         }
     }
 }
@@ -355,10 +355,10 @@ pub struct EventedHandle<T> {
 impl<T: mio::Evented> EventedHandle<T> {
     fn new(inner: SharableEvented<T>, request_tx: RequestSender, token: mio::Token) -> Self {
         EventedHandle {
-            token: token,
-            request_tx: request_tx,
+            token,
+            request_tx,
             shared_count: Arc::new(AtomicUsize::new(1)),
-            inner: inner,
+            inner,
         }
     }
 

--- a/src/io/poll/poller.rs
+++ b/src/io/poll/poller.rs
@@ -1,20 +1,20 @@
 // Copyright (c) 2016 DWANGO Co., Ltd. All Rights Reserved.
 // See the LICENSE file at the top-level directory of this distribution.
 
-use std::io;
-use std::fmt;
-use std::time;
-use std::collections::HashMap;
-use std::sync::mpsc::{RecvError, TryRecvError};
-use std::sync::Arc;
-use std::sync::atomic::{self, AtomicUsize};
 use futures::{self, Future};
 use mio;
 use nbchan::mpsc as nb_mpsc;
+use std::collections::HashMap;
+use std::fmt;
+use std::io;
+use std::sync::Arc;
+use std::sync::atomic::{self, AtomicUsize};
+use std::sync::mpsc::{RecvError, TryRecvError};
+use std::time;
 
-use sync::oneshot;
-use collections::HeapMap;
 use super::{EventedLock, Interest, SharableEvented};
+use collections::HeapMap;
+use sync::oneshot;
 
 type RequestSender = nb_mpsc::Sender<Request>;
 type RequestReceiver = nb_mpsc::Receiver<Request>;

--- a/src/io/stdio.rs
+++ b/src/io/stdio.rs
@@ -48,8 +48,8 @@ pub fn stdin() -> Stdin {
     });
     Stdin {
         lock_requested: false,
-        req_tx: req_tx,
-        res_rx: res_rx,
+        req_tx,
+        res_rx,
     }
 }
 

--- a/src/io/stdio.rs
+++ b/src/io/stdio.rs
@@ -2,11 +2,11 @@
 // See the LICENSE file at the top-level directory of this distribution.
 
 //! Non-blocking variants of standard I/O streams.
-use std::io::{self, Read};
-use std::error;
-use std::thread;
-use std::sync::mpsc as std_mpsc;
 use futures::{Async, Stream};
+use std::error;
+use std::io::{self, Read};
+use std::sync::mpsc as std_mpsc;
+use std::thread;
 
 use sync::mpsc as fibers_mpsc;
 
@@ -14,9 +14,9 @@ macro_rules! break_if_err {
     ($e:expr) => {
         match $e {
             Err(_) => break,
-            Ok(v) => v
+            Ok(v) => v,
         }
-    }
+    };
 }
 
 /// Returns a non-blocking variant of the standard input stream (i.e., `std::io::Stdin`).

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -186,7 +186,6 @@
 #![warn(missing_docs)]
 
 extern crate futures;
-extern crate handy_async;
 extern crate mio;
 extern crate nbchan;
 extern crate num_cpus;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -194,9 +194,13 @@ extern crate splay_tree;
 
 macro_rules! assert_some {
     ($e:expr) => {
-        $e.expect(&format!("[{}:{}] {:?} must be a Some(..)",
-                           file!(), line!(), stringify!($e)))
-    }
+        $e.expect(&format!(
+            "[{}:{}] {:?} must be a Some(..)",
+            file!(),
+            line!(),
+            stringify!($e)
+        ))
+    };
 }
 
 #[doc(inline)]
@@ -205,12 +209,12 @@ pub use self::executor::{Executor, InPlaceExecutor, ThreadPoolExecutor};
 #[doc(inline)]
 pub use self::fiber::{BoxSpawn, Spawn};
 
+pub mod executor;
+pub mod fiber;
 pub mod io;
 pub mod net;
 pub mod sync;
 pub mod time;
-pub mod fiber;
-pub mod executor;
 
 mod collections;
 mod sync_atomic;

--- a/src/net/mod.rs
+++ b/src/net/mod.rs
@@ -17,32 +17,32 @@
 //! indicates the socket becomes available.
 //! After that, when the event happens, the fiber will be resumed and
 //! rescheduled for next execution.
+use futures::{Async, Future, Poll};
+use mio;
+use std::error;
+use std::fmt;
 use std::io;
 use std::mem;
-use std::fmt;
-use std::error;
 use std::net::SocketAddr;
-use mio;
-use futures::{Async, Future, Poll};
 
-pub use self::udp::UdpSocket;
 pub use self::tcp::{TcpListener, TcpStream};
+pub use self::udp::UdpSocket;
 
 use fiber;
 use io::poll::{EventedHandle, Register};
 
 pub mod futures {
     //! Implementations of `futures::Future` trait.
-    pub use super::udp::{RecvFrom, SendTo, UdpSocketBind};
     pub use super::tcp::{Connect, Connected, TcpListenerBind};
+    pub use super::udp::{RecvFrom, SendTo, UdpSocketBind};
 }
 pub mod streams {
     //! Implementations of `futures::Stream` trait.
     pub use super::tcp::Incoming;
 }
 
-mod udp;
 mod tcp;
+mod udp;
 
 enum Bind<F, T> {
     Bind(SocketAddr, F),
@@ -60,8 +60,8 @@ where
         match mem::replace(self, Bind::Polled) {
             Bind::Bind(addr, bind) => {
                 let socket = bind(&addr)?;
-                let register = assert_some!(fiber::with_current_context(|mut c| c.poller()
-                    .register(socket),));
+                let register =
+                    assert_some!(fiber::with_current_context(|mut c| c.poller().register(socket),));
                 *self = Bind::Registering(register);
                 self.poll()
             }

--- a/src/net/tcp.rs
+++ b/src/net/tcp.rs
@@ -124,7 +124,7 @@ impl Future for TcpListenerBind {
     type Error = io::Error;
     fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
         Ok(self.0.poll()?.map(|handle| TcpListener {
-            handle: handle,
+            handle,
             monitor: None,
         }))
     }
@@ -276,7 +276,7 @@ impl Clone for TcpStream {
 impl TcpStream {
     fn new(handle: EventedHandle<MioTcpStream>) -> Self {
         TcpStream {
-            handle: handle,
+            handle,
             read_monitor: None,
             write_monitor: None,
         }

--- a/src/net/tcp.rs
+++ b/src/net/tcp.rs
@@ -1,18 +1,18 @@
 // Copyright (c) 2016 DWANGO Co., Ltd. All Rights Reserved.
 // See the LICENSE file at the top-level directory of this distribution.
 
+use futures::{Async, Future, Poll, Stream};
+use mio;
+use mio::net::{TcpListener as MioTcpListener, TcpStream as MioTcpStream};
 use std::fmt;
 use std::io;
 use std::mem;
 use std::net::SocketAddr;
-use futures::{Async, Future, Poll, Stream};
-use mio;
-use mio::net::{TcpListener as MioTcpListener, TcpStream as MioTcpStream};
 
+use super::{into_io_error, Bind};
 use fiber::{self, Context};
 use io::poll::{EventedHandle, Interest, Register};
 use sync::oneshot::Monitor;
-use super::{into_io_error, Bind};
 
 /// A structure representing a socket server.
 ///
@@ -419,8 +419,8 @@ impl Future for ConnectInner {
         match mem::replace(self, ConnectInner::Polled) {
             ConnectInner::Connect(addr) => {
                 let stream = MioTcpStream::connect(&addr)?;
-                let register = assert_some!(fiber::with_current_context(|mut c| c.poller()
-                    .register(stream),));
+                let register =
+                    assert_some!(fiber::with_current_context(|mut c| c.poller().register(stream),));
                 *self = ConnectInner::Registering(register);
                 self.poll()
             }

--- a/src/net/tcp.rs
+++ b/src/net/tcp.rs
@@ -306,6 +306,16 @@ impl TcpStream {
         self.handle.inner().take_error()
     }
 
+    /// Gets the value of the `TCP_NODELAY` option on this socket.
+    pub fn nodelay(&self) -> io::Result<bool> {
+        self.handle.inner().nodelay()
+    }
+
+    /// Sets the value of the `TCP_NODELAY `option on this socket.
+    pub fn set_nodelay(&self, nodelay: bool) -> io::Result<()> {
+        self.handle.inner().set_nodelay(nodelay)
+    }
+
     /// Calls `f` with the reference to the inner socket.
     pub unsafe fn with_inner<F, T>(&self, f: F) -> T
     where

--- a/src/net/udp.rs
+++ b/src/net/udp.rs
@@ -70,8 +70,8 @@ impl UdpSocket {
     pub fn send_to<B: AsRef<[u8]>>(self, buf: B, target: SocketAddr) -> SendTo<B> {
         SendTo(Some(SendToInner {
             socket: self,
-            buf: buf,
-            target: target,
+            buf,
+            target,
             monitor: None,
         }))
     }
@@ -80,7 +80,7 @@ impl UdpSocket {
     pub fn recv_from<B: AsMut<[u8]>>(self, buf: B) -> RecvFrom<B> {
         RecvFrom(Some(RecvFromInner {
             socket: self,
-            buf: buf,
+            buf,
             monitor: None,
         }))
     }
@@ -132,7 +132,7 @@ impl Future for UdpSocketBind {
     type Item = UdpSocket;
     type Error = io::Error;
     fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
-        Ok(self.0.poll()?.map(|handle| UdpSocket { handle: handle }))
+        Ok(self.0.poll()?.map(|handle| UdpSocket { handle }))
     }
 }
 

--- a/src/net/udp.rs
+++ b/src/net/udp.rs
@@ -1,15 +1,15 @@
 // Copyright (c) 2016 DWANGO Co., Ltd. All Rights Reserved.
 // See the LICENSE file at the top-level directory of this distribution.
 
+use futures::{Async, Future, Poll};
+use mio::net::UdpSocket as MioUdpSocket;
 use std::fmt;
 use std::io;
 use std::net::SocketAddr;
-use futures::{Async, Future, Poll};
-use mio::net::UdpSocket as MioUdpSocket;
 
+use super::{into_io_error, Bind};
 use io::poll::{EventedHandle, Interest};
 use sync::oneshot::Monitor;
-use super::{into_io_error, Bind};
 
 /// A User Datagram Protocol socket.
 ///

--- a/src/sync/mpsc.rs
+++ b/src/sync/mpsc.rs
@@ -121,12 +121,13 @@ pub fn channel<T>() -> (Sender<T>, Receiver<T>) {
         },
         Receiver {
             inner: rx,
-            notifier: notifier,
+            notifier,
         },
     )
 }
 
 /// Creates a new synchronous, bounded channel.
+#[deprecated]
 pub fn sync_channel<T>(bound: usize) -> (SyncSender<T>, Receiver<T>) {
     let notifier = Notifier::new();
     let (tx, rx) = nb_mpsc::sync_channel(bound);
@@ -137,7 +138,7 @@ pub fn sync_channel<T>(bound: usize) -> (SyncSender<T>, Receiver<T>) {
         },
         Receiver {
             inner: rx,
-            notifier: notifier,
+            notifier,
         },
     )
 }

--- a/src/sync/mpsc.rs
+++ b/src/sync/mpsc.rs
@@ -61,10 +61,10 @@
 //! an object shared with the senders.
 //! If a corresponding sender finds there is a waiting receiver,
 //! it will resume (reschedule) the fiber, after sending a message.
-use std::fmt;
-use std::sync::mpsc::{SendError, TryRecvError, TrySendError};
 use futures::{Async, AsyncSink, Poll, Sink, StartSend, Stream};
 use nbchan::mpsc as nb_mpsc;
+use std::fmt;
+use std::sync::mpsc::{SendError, TryRecvError, TrySendError};
 
 use super::Notifier;
 

--- a/src/sync/oneshot.rs
+++ b/src/sync/oneshot.rs
@@ -15,11 +15,11 @@
 //!
 //! The former essentially have the same semantics as the latter.
 //! But those are useful to clarify the intention of programmers.
-use std::fmt;
-use std::error;
-use std::sync::mpsc::{RecvError, SendError};
 use futures::{Async, Future, Poll};
 use nbchan;
+use std::error;
+use std::fmt;
+use std::sync::mpsc::{RecvError, SendError};
 
 use super::Notifier;
 

--- a/src/sync_atomic.rs
+++ b/src/sync_atomic.rs
@@ -45,7 +45,7 @@ pub struct AtomicBorrowMut<'a, T: 'a> {
 impl<'a, T> AtomicBorrowMut<'a, T> {
     fn new(owner: &'a AtomicCell<T>, inner: Box<T>) -> Self {
         AtomicBorrowMut {
-            owner: owner,
+            owner,
             inner: Some(inner),
         }
     }

--- a/src/time.rs
+++ b/src/time.rs
@@ -4,12 +4,12 @@
 //! Time related functionalities.
 pub mod timer {
     //! Timer
-    use std::time;
-    use std::sync::mpsc::RecvError;
     use futures::{Async, Future, Poll};
+    use std::sync::mpsc::RecvError;
+    use std::time;
 
-    use io::poll;
     use fiber::{self, Context};
+    use io::poll;
 
     /// A timer related extension of the `Future` trait.
     pub trait TimerExt: Sized + Future {
@@ -94,9 +94,9 @@ pub mod timer {
 
     #[cfg(test)]
     mod test {
-        use std::time::Duration;
-        use futures::{self, Async, Future};
         use super::*;
+        use futures::{self, Async, Future};
+        use std::time::Duration;
 
         #[test]
         fn it_works() {


### PR DESCRIPTION
`v0.1.10` includes following changes:

- Apply the up-to-date code formatter and lint
- Export some TCP socket methods for convenience (e.g., `TcpStream::set_nodelay` )
- Remove `handy_async` from dependencies (the library is no longer necessary)