### PR TITLE
Version 0.1.11

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fibers"
-version = "0.1.10"
+version = "0.1.11"
 authors = ["Takeru Ohta <takeru_ohta@dwango.co.jp>"]
 description = "A Rust library to execute a number of lightweight asynchronous tasks (a.k.a, fibers) based on futures and mio"
 homepage = "https://github.com/dwango/fibers-rs"

--- a/src/fiber/mod.rs
+++ b/src/fiber/mod.rs
@@ -8,8 +8,8 @@
 use futures::future::Either;
 use futures::{self, Async, Future, IntoFuture, Poll};
 use std::fmt;
-use std::sync::Arc;
 use std::sync::atomic::{self, AtomicUsize};
+use std::sync::Arc;
 
 pub use self::schedule::{with_current_context, yield_poll, Context};
 pub use self::schedule::{Scheduler, SchedulerHandle, SchedulerId};

--- a/src/io/poll/mod.rs
+++ b/src/io/poll/mod.rs
@@ -14,8 +14,8 @@ use std::io;
 use std::ops;
 use std::sync::Arc;
 
-pub use self::poller::{Register, DEFAULT_EVENTS_CAPACITY};
 pub use self::poller::{EventedHandle, Poller, PollerHandle};
+pub use self::poller::{Register, DEFAULT_EVENTS_CAPACITY};
 
 use sync_atomic::{AtomicBorrowMut, AtomicCell};
 

--- a/src/io/poll/poller.rs
+++ b/src/io/poll/poller.rs
@@ -7,9 +7,9 @@ use nbchan::mpsc as nb_mpsc;
 use std::collections::HashMap;
 use std::fmt;
 use std::io;
-use std::sync::Arc;
 use std::sync::atomic::{self, AtomicUsize};
 use std::sync::mpsc::{RecvError, TryRecvError};
+use std::sync::Arc;
 use std::time;
 
 use super::{EventedLock, Interest, SharableEvented};

--- a/src/net/mod.rs
+++ b/src/net/mod.rs
@@ -60,8 +60,9 @@ where
         match mem::replace(self, Bind::Polled) {
             Bind::Bind(addr, bind) => {
                 let socket = bind(&addr)?;
-                let register =
-                    assert_some!(fiber::with_current_context(|mut c| c.poller().register(socket),));
+                let register = assert_some!(fiber::with_current_context(
+                    |mut c| c.poller().register(socket),
+                ));
                 *self = Bind::Registering(register);
                 self.poll()
             }

--- a/src/net/tcp.rs
+++ b/src/net/tcp.rs
@@ -429,8 +429,9 @@ impl Future for ConnectInner {
         match mem::replace(self, ConnectInner::Polled) {
             ConnectInner::Connect(addr) => {
                 let stream = MioTcpStream::connect(&addr)?;
-                let register =
-                    assert_some!(fiber::with_current_context(|mut c| c.poller().register(stream),));
+                let register = assert_some!(fiber::with_current_context(
+                    |mut c| c.poller().register(stream),
+                ));
                 *self = ConnectInner::Registering(register);
                 self.poll()
             }

--- a/src/sync/mpsc.rs
+++ b/src/sync/mpsc.rs
@@ -198,6 +198,11 @@ impl<T> Sender<T> {
         self.notifier.notify();
         Ok(())
     }
+
+    /// Returns `true` if the receiver has dropped, otherwise `false`.
+    pub fn is_disconnected(&self) -> bool {
+        self.inner.is_disconnected()
+    }
 }
 unsafe impl<T: Send> Sync for Sender<T> {}
 impl<T> Clone for Sender<T> {


### PR DESCRIPTION
`v0.1.11` includes following changes:
- Apply the up-to-date code formatter (i.e., `rustfmt-v0.6.1` )
- Add `Sender::is_disconnected` method for detecting receiver's down without sending a message
