### PR TITLE
Manage lifetime of EventedHandle by using Arc<Self>

### DIFF
--- a/src/net/mod.rs
+++ b/src/net/mod.rs
@@ -24,6 +24,7 @@ use std::fmt;
 use std::io;
 use std::mem;
 use std::net::SocketAddr;
+use std::sync::Arc;
 
 pub use self::tcp::{TcpListener, TcpStream};
 pub use self::udp::UdpSocket;
@@ -54,7 +55,7 @@ where
     F: FnOnce(&SocketAddr) -> io::Result<T>,
     T: mio::Evented + Send + 'static,
 {
-    type Item = EventedHandle<T>;
+    type Item = Arc<EventedHandle<T>>;
     type Error = io::Error;
     fn poll(&mut self) -> Poll<Self::Item, Self::Error> {
         match mem::replace(self, Bind::Polled) {

--- a/src/net/tcp.rs
+++ b/src/net/tcp.rs
@@ -8,6 +8,7 @@ use std::fmt;
 use std::io;
 use std::mem;
 use std::net::SocketAddr;
+use std::sync::Arc;
 
 use super::{into_io_error, Bind};
 use fiber::{self, Context};
@@ -62,7 +63,7 @@ use sync::oneshot::Monitor;
 /// # }
 /// ```
 pub struct TcpListener {
-    handle: EventedHandle<MioTcpListener>,
+    handle: Arc<EventedHandle<MioTcpListener>>,
     monitor: Option<Monitor<(), io::Error>>,
 }
 impl TcpListener {
@@ -260,7 +261,7 @@ impl Future for Connected {
 /// # }
 /// ```
 pub struct TcpStream {
-    handle: EventedHandle<MioTcpStream>,
+    handle: Arc<EventedHandle<MioTcpStream>>,
     read_monitor: Option<Monitor<(), io::Error>>,
     write_monitor: Option<Monitor<(), io::Error>>,
 }
@@ -274,7 +275,7 @@ impl Clone for TcpStream {
     }
 }
 impl TcpStream {
-    fn new(handle: EventedHandle<MioTcpStream>) -> Self {
+    fn new(handle: Arc<EventedHandle<MioTcpStream>>) -> Self {
         TcpStream {
             handle,
             read_monitor: None,

--- a/src/net/udp.rs
+++ b/src/net/udp.rs
@@ -6,6 +6,7 @@ use mio::net::UdpSocket as MioUdpSocket;
 use std::fmt;
 use std::io;
 use std::net::SocketAddr;
+use std::sync::Arc;
 
 use super::{into_io_error, Bind};
 use io::poll::{EventedHandle, Interest};
@@ -58,7 +59,7 @@ use sync::oneshot::Monitor;
 /// ```
 #[derive(Clone)]
 pub struct UdpSocket {
-    handle: EventedHandle<MioUdpSocket>,
+    handle: Arc<EventedHandle<MioUdpSocket>>,
 }
 impl UdpSocket {
     /// Makes a future to create a UDP socket binded to the given address.


### PR DESCRIPTION
# What is changed

Change `EventedHandle` to create  `Arc<Self>` instead of `Self`, to manage lifetimes of them in place of reference counting by self.

# Background

`EventedHandle` in `poller` manages own lifetime and timing of dropping on itself by using `Arc<AtomicUsize>`. I think this semantics will be replaced by wrapping entire of `EventedHandle` into `Arc` and that it will improve cost performance by reducing memory copies which is implemented by `Clone` trait currently.