### PR TITLE
Stop deprecating sync_channel

### DIFF
--- a/src/sync/mpsc.rs
+++ b/src/sync/mpsc.rs
@@ -127,7 +127,6 @@ pub fn channel<T>() -> (Sender<T>, Receiver<T>) {
 }
 
 /// Creates a new synchronous, bounded channel.
-#[deprecated]
 pub fn sync_channel<T>(bound: usize) -> (SyncSender<T>, Receiver<T>) {
     let notifier = Notifier::new();
     let (tx, rx) = nb_mpsc::sync_channel(bound);


### PR DESCRIPTION
I'd like to use `fibers::sync::mpsc::sync_channel` in [my current job in frugalos](https://github.com/frugalos/frugalos/pull/166/commits/aa69c6eff7d9dde611b0b6742b822f668616f5ba), but it is deprecated.

I tried to find out why and found the commit https://github.com/dwango/fibers-rs/commit/e4a20ca27dc11df248eb67804f841948bbbe02fe and the PR https://github.com/dwango/fibers-rs/pull/7 this deprecation happens in, but couldn't find comments to justify it.

Any ideas?