### PR TITLE
Apply cargo fmt, make clippy happy, fix .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,24 @@
 language: rust
+
 rust:
   - stable
   - beta
   - nightly
+
 matrix:
   allow_failures:
     - rust: nightly
   fast_finish: true
+
+before_script:
+  - rustup component add clippy rustfmt
+  - cargo clippy --version
+
+script:
+  - cargo test --all
+  - cargo clippy --all --all-targets
+  - cargo fmt -- --check
+
+env:
+  global:
+  - RUSTFLAGS="-D warnings"

--- a/src/fiber/schedule.rs
+++ b/src/fiber/schedule.rs
@@ -11,7 +11,7 @@ use super::{FiberState, Spawn};
 use fiber::{self, Task};
 use io::poll;
 
-static mut NEXT_SCHEDULER_ID: atomic::AtomicUsize = atomic::ATOMIC_USIZE_INIT;
+static mut NEXT_SCHEDULER_ID: atomic::AtomicUsize = atomic::AtomicUsize::new(0);
 
 thread_local! {
     static CURRENT_CONTEXT: RefCell<InnerContext> = {

--- a/src/io/poll/poller.rs
+++ b/src/io/poll/poller.rs
@@ -190,10 +190,9 @@ impl Poller {
                 }
             }
             Request::SetTimeout(timeout_id, expiry_time, reply) => {
-                assert!(
-                    self.timeout_queue
-                        .push_if_absent((expiry_time, timeout_id), reply,)
-                );
+                assert!(self
+                    .timeout_queue
+                    .push_if_absent((expiry_time, timeout_id), reply,));
             }
             Request::CancelTimeout(timeout_id, expiry_time) => {
                 self.timeout_queue.remove(&(expiry_time, timeout_id));


### PR DESCRIPTION
This PR achieves basically two things:
- apply `cargo fmt`, make CI run `cargo fmt`
- `cargo clippy` does not make any warnings, make CI run `cargo clippy --all --all-targets`

This PR does not change the behavior of exported modules.