### PR TITLE
Use dyn Trait instead of bare trait

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ fn main() {
     assert_eq!(answer, Ok(55));
 }
 
-fn fibonacci<H: Spawn + Clone>(n: usize, handle: H) -> Box<Future<Item=usize, Error=()> + Send> {
+fn fibonacci<H: Spawn + Clone>(n: usize, handle: H) -> Box<dyn Future<Item=usize, Error=()> + Send> {
     if n < 2 {
         Box::new(futures::finished(n))
     } else {

--- a/examples/fibonacci.rs
+++ b/examples/fibonacci.rs
@@ -26,7 +26,7 @@ fn main() {
     println!("fibonacci({}) = {}", input_number, answer);
 }
 
-fn fibonacci<H: Spawn>(n: usize, handle: &H) -> Box<Future<Item = usize, Error = ()> + Send> {
+fn fibonacci<H: Spawn>(n: usize, handle: &H) -> Box<dyn Future<Item = usize, Error = ()> + Send> {
     if n < 2 {
         Box::new(futures::finished(n))
     } else {

--- a/src/executor/in_place.rs
+++ b/src/executor/in_place.rs
@@ -21,7 +21,7 @@ use io::poll;
 /// use fibers::{Spawn, Executor, InPlaceExecutor};
 /// use futures::{Async, Future};
 ///
-/// fn fib<H: Spawn + Clone>(n: usize, handle: H) -> Box<Future<Item=usize, Error=()> + Send> {
+/// fn fib<H: Spawn + Clone>(n: usize, handle: H) -> Box<dyn Future<Item=usize, Error=()> + Send> {
 ///     if n < 2 {
 ///         Box::new(futures::finished(n))
 ///     } else {
@@ -73,7 +73,7 @@ impl Executor for InPlaceExecutor {
     }
 }
 impl Spawn for InPlaceExecutor {
-    fn spawn_boxed(&self, fiber: Box<Future<Item = (), Error = ()> + Send>) {
+    fn spawn_boxed(&self, fiber: Box<dyn Future<Item = (), Error = ()> + Send>) {
         self.handle().spawn_boxed(fiber)
     }
 }
@@ -84,7 +84,7 @@ pub struct InPlaceExecutorHandle {
     scheduler: fiber::SchedulerHandle,
 }
 impl Spawn for InPlaceExecutorHandle {
-    fn spawn_boxed(&self, fiber: Box<Future<Item = (), Error = ()> + Send>) {
+    fn spawn_boxed(&self, fiber: Box<dyn Future<Item = (), Error = ()> + Send>) {
         self.scheduler.spawn_boxed(fiber)
     }
 }

--- a/src/executor/thread_pool.rs
+++ b/src/executor/thread_pool.rs
@@ -27,7 +27,7 @@ use sync::oneshot::{self, Link};
 /// use fibers::{Spawn, Executor, ThreadPoolExecutor};
 /// use futures::{Async, Future};
 ///
-/// fn fib<H: Spawn + Clone>(n: usize, handle: H) -> Box<Future<Item=usize, Error=()> + Send> {
+/// fn fib<H: Spawn + Clone>(n: usize, handle: H) -> Box<dyn Future<Item=usize, Error=()> + Send> {
 ///     if n < 2 {
 ///         Box::new(futures::finished(n))
 ///     } else {
@@ -124,7 +124,7 @@ impl Executor for ThreadPoolExecutor {
     }
 }
 impl Spawn for ThreadPoolExecutor {
-    fn spawn_boxed(&self, fiber: Box<Future<Item = (), Error = ()> + Send>) {
+    fn spawn_boxed(&self, fiber: Box<dyn Future<Item = (), Error = ()> + Send>) {
         self.handle().spawn_boxed(fiber)
     }
 }
@@ -135,7 +135,7 @@ pub struct ThreadPoolExecutorHandle {
     spawn_tx: nb_mpsc::Sender<Task>,
 }
 impl Spawn for ThreadPoolExecutorHandle {
-    fn spawn_boxed(&self, fiber: Box<Future<Item = (), Error = ()> + Send>) {
+    fn spawn_boxed(&self, fiber: Box<dyn Future<Item = (), Error = ()> + Send>) {
         let _ = self.spawn_tx.send(Task(fiber));
     }
 }

--- a/src/fiber/mod.rs
+++ b/src/fiber/mod.rs
@@ -29,7 +29,7 @@ pub type ContextId = (SchedulerId, FiberId);
 /// The `Spawn` trait allows for spawning fibers.
 pub trait Spawn {
     /// Spawns a fiber which will execute given boxed future.
-    fn spawn_boxed(&self, fiber: Box<Future<Item = (), Error = ()> + Send>);
+    fn spawn_boxed(&self, fiber: Box<dyn Future<Item = (), Error = ()> + Send>);
 
     /// Spawns a fiber which will execute given future.
     fn spawn<F>(&self, fiber: F)
@@ -124,12 +124,12 @@ pub trait Spawn {
     }
 }
 
-type BoxFn = Box<Fn(Box<Future<Item = (), Error = ()> + Send>) + Send + 'static>;
+type BoxFn = Box<dyn Fn(Box<dyn Future<Item = (), Error = ()> + Send>) + Send + 'static>;
 
 /// Boxed `Spawn` object.
 pub struct BoxSpawn(BoxFn);
 impl Spawn for BoxSpawn {
-    fn spawn_boxed(&self, fiber: Box<Future<Item = (), Error = ()> + Send>) {
+    fn spawn_boxed(&self, fiber: Box<dyn Future<Item = (), Error = ()> + Send>) {
         (self.0)(fiber);
     }
     fn boxed(self) -> BoxSpawn
@@ -223,7 +223,7 @@ impl Drop for Unpark {
     }
 }
 
-pub(crate) type FiberFuture = Box<Future<Item = (), Error = ()> + Send>;
+pub(crate) type FiberFuture = Box<dyn Future<Item = (), Error = ()> + Send>;
 
 pub(crate) struct Task(pub FiberFuture);
 impl fmt::Debug for Task {

--- a/src/fiber/schedule.rs
+++ b/src/fiber/schedule.rs
@@ -207,7 +207,7 @@ impl SchedulerHandle {
     }
 }
 impl Spawn for SchedulerHandle {
-    fn spawn_boxed(&self, fiber: Box<Future<Item = (), Error = ()> + Send>) {
+    fn spawn_boxed(&self, fiber: Box<dyn Future<Item = (), Error = ()> + Send>) {
         let _ = self.request_tx.send(Request::Spawn(Task(fiber)));
     }
 }

--- a/src/io/poll/poller.rs
+++ b/src/io/poll/poller.rs
@@ -381,14 +381,14 @@ impl<T> Drop for EventedHandle<T> {
     }
 }
 
-struct BoxEvented(Box<mio::Evented + Send + 'static>);
+struct BoxEvented(Box<dyn mio::Evented + Send + 'static>);
 impl fmt::Debug for BoxEvented {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "BoxEvented(_)")
     }
 }
 
-struct RegisterReplyFn(Box<FnMut(mio::Token) + Send + 'static>);
+struct RegisterReplyFn(Box<dyn FnMut(mio::Token) + Send + 'static>);
 impl fmt::Debug for RegisterReplyFn {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "RegisterReplyFn(_)")

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -80,7 +80,7 @@
 //! use fibers::{Spawn, Executor, ThreadPoolExecutor};
 //! use futures::Future;
 //!
-//! fn fibonacci<H: Spawn + Clone>(n: usize, handle: H) -> Box<Future<Item=usize, Error=()> + Send> {
+//! fn fibonacci<H: Spawn + Clone>(n: usize, handle: H) -> Box<dyn Future<Item=usize, Error=()> + Send> {
 //!     if n < 2 {
 //!         Box::new(futures::finished(n))
 //!     } else {

--- a/src/net/tcp.rs
+++ b/src/net/tcp.rs
@@ -449,7 +449,7 @@ impl Future for ConnectInner {
                 Ok(_) => Ok(Async::Ready(stream)),
                 Err(e) => {
                     if let Some(e) = stream.take_error()? {
-                        Err(e)?;
+                        return Err(e);
                     }
                     if e.kind() == io::ErrorKind::NotConnected {
                         let retry = stream.start_monitor_if_needed(Interest::Write)?;

--- a/src/sync/oneshot.rs
+++ b/src/sync/oneshot.rs
@@ -336,7 +336,7 @@ impl<E: error::Error> error::Error for MonitorError<E> {
             MonitorError::Failed(_) => "Monitor target failed: {}",
         }
     }
-    fn cause(&self) -> Option<&error::Error> {
+    fn cause(&self) -> Option<&dyn error::Error> {
         match *self {
             MonitorError::Aborted => None,
             MonitorError::Failed(ref e) => Some(e),


### PR DESCRIPTION
Since rustc 1.37.0, usages of bare trait object warn by default. https://github.com/rust-lang/rust/blob/master/RELEASES.md#compatibility-notes
All usages of bare traits are replaced with dyn Trait.