### PR TITLE
doctest 内の不要な `fn main` を削除

### DIFF
--- a/src/executor/in_place.rs
+++ b/src/executor/in_place.rs
@@ -31,7 +31,6 @@ use io::poll;
 ///     }
 /// }
 ///
-/// # fn main() {
 /// let mut executor = InPlaceExecutor::new().unwrap();
 /// let mut monitor = executor.spawn_monitor(fib(7, executor.handle()));
 /// loop {
@@ -42,7 +41,6 @@ use io::poll;
 ///         executor.run_once().unwrap();
 ///     }
 /// }
-/// # }
 /// ```
 #[derive(Debug)]
 pub struct InPlaceExecutor {

--- a/src/executor/thread_pool.rs
+++ b/src/executor/thread_pool.rs
@@ -37,12 +37,10 @@ use sync::oneshot::{self, Link};
 ///     }
 /// }
 ///
-/// # fn main() {
 /// let mut executor = ThreadPoolExecutor::new().unwrap();
 /// let monitor = executor.spawn_monitor(fib(7, executor.handle()));
 /// let answer = executor.run_fiber(monitor).unwrap();
 /// assert_eq!(answer, Ok(13));
-/// # }
 /// ```
 #[derive(Debug)]
 pub struct ThreadPoolExecutor {

--- a/src/fiber/mod.rs
+++ b/src/fiber/mod.rs
@@ -77,7 +77,6 @@ pub trait Spawn {
     /// use fibers::{Executor, InPlaceExecutor, Spawn};
     /// use futures::{Future, empty};
     ///
-    /// # fn main() {
     /// let mut executor = InPlaceExecutor::new().unwrap();
     /// let (tx, rx) = oneshot::channel();
     /// let fiber = empty().and_then(move |()| tx.send(()));
@@ -88,7 +87,6 @@ pub trait Spawn {
     ///
     /// // Channel `rx` is disconnected (e.g., `fiber` exited).
     /// assert!(executor.run_future(rx).unwrap().is_err());
-    /// # }
     /// ```
     fn spawn_link<F, T, E>(&self, f: F) -> Link<(), (), T, E>
     where

--- a/src/fiber/schedule.rs
+++ b/src/fiber/schedule.rs
@@ -291,12 +291,10 @@ impl<'a> Context<'a> {
 ///     }
 /// }
 ///
-/// # fn main() {
 /// let mut executor = InPlaceExecutor::new().unwrap();
 /// let monitor = executor.spawn_monitor(HeavyCalculation::new(100));
 /// let result = executor.run_fiber(monitor).unwrap();
 /// assert_eq!(result, Ok(11));
-/// # }
 /// ```
 pub fn yield_poll<T, E>() -> Poll<T, E> {
     with_current_context(|context| context.fiber.yield_once());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -91,7 +91,6 @@
 //!     }
 //! }
 //!
-//! # fn main() {
 //! // Creates an executor instance.
 //! let mut executor = ThreadPoolExecutor::new().unwrap();
 //!
@@ -105,7 +104,6 @@
 //!
 //! // Checkes the answer.
 //! assert_eq!(answer, Ok(55));
-//! # }
 //! ```
 //!
 //! ### TCP Echo Server
@@ -123,7 +121,6 @@
 //! use handy_async::io::{AsyncWrite, ReadFrom};
 //! use handy_async::pattern::AllowPartial;
 //!
-//! # fn main() {
 //! let server_addr = "127.0.0.1:3000".parse().expect("Invalid TCP bind address");
 //!
 //! let mut executor = ThreadPoolExecutor::new().expect("Cannot create Executor");
@@ -181,7 +178,6 @@
 //!     }));
 //! let result = executor.run_fiber(monitor).expect("Execution failed");
 //! println!("# Listener finished: {:?}", result);
-//! # }
 //! ```
 #![warn(missing_docs)]
 

--- a/src/net/tcp.rs
+++ b/src/net/tcp.rs
@@ -28,7 +28,6 @@ use sync::oneshot::Monitor;
 /// use fibers::sync::oneshot;
 /// use futures::{Future, Stream};
 ///
-/// # fn main() {
 /// let mut executor = InPlaceExecutor::new().unwrap();
 /// let (addr_tx, addr_rx) = oneshot::channel();
 ///
@@ -60,7 +59,6 @@ use sync::oneshot::Monitor;
 ///     executor.run_once().unwrap();
 /// }
 /// println!("# Succeeded");
-/// # }
 /// ```
 pub struct TcpListener {
     handle: Arc<EventedHandle<MioTcpListener>>,
@@ -224,7 +222,6 @@ impl Future for Connected {
 /// use fibers::sync::oneshot;
 /// use futures::{Future, Stream};
 ///
-/// # fn main() {
 /// let mut executor = InPlaceExecutor::new().unwrap();
 /// let (addr_tx, addr_rx) = oneshot::channel();
 ///
@@ -258,7 +255,6 @@ impl Future for Connected {
 ///     executor.run_once().unwrap();
 /// }
 /// println!("# Succeeded");
-/// # }
 /// ```
 pub struct TcpStream {
     handle: Arc<EventedHandle<MioTcpStream>>,

--- a/src/net/udp.rs
+++ b/src/net/udp.rs
@@ -25,7 +25,6 @@ use sync::oneshot::Monitor;
 /// use fibers::sync::oneshot;
 /// use futures::Future;
 ///
-/// # fn main() {
 /// let mut executor = InPlaceExecutor::new().unwrap();
 /// let (addr_tx, addr_rx) = oneshot::channel();
 ///
@@ -55,7 +54,6 @@ use sync::oneshot::Monitor;
 /// while monitor.poll().unwrap().is_not_ready() {
 ///     executor.run_once().unwrap();
 /// }
-/// # }
 /// ```
 #[derive(Clone)]
 pub struct UdpSocket {

--- a/src/sync/mpsc.rs
+++ b/src/sync/mpsc.rs
@@ -18,7 +18,6 @@
 //! use fibers::sync::mpsc;
 //! use futures::{Future, Stream};
 //!
-//! # fn main() {
 //! let mut executor = InPlaceExecutor::new().unwrap();
 //! let (tx0, rx) = mpsc::channel();
 //!
@@ -45,7 +44,6 @@
 //! while monitor.poll().unwrap().is_not_ready() {
 //!     executor.run_once().unwrap();
 //! }
-//! # }
 //! ```
 //!
 //! # Note
@@ -82,7 +80,6 @@ use super::Notifier;
 /// use fibers::sync::mpsc;
 /// use futures::{Future, Stream};
 ///
-/// # fn main() {
 /// let mut executor = InPlaceExecutor::new().unwrap();
 /// let (tx0, rx) = mpsc::channel();
 ///
@@ -109,7 +106,6 @@ use super::Notifier;
 /// while monitor.poll().unwrap().is_not_ready() {
 ///     executor.run_once().unwrap();
 /// }
-/// # }
 /// ```
 pub fn channel<T>() -> (Sender<T>, Receiver<T>) {
     let notifier = Notifier::new();


### PR DESCRIPTION
beta 版の cargo-clippy が警告を出すようになり、CI が落ちるようになったため。