### PR TITLE
fix: Fixed some minor spelling errors.

### DIFF
--- a/src/fiber/schedule.rs
+++ b/src/fiber/schedule.rs
@@ -31,7 +31,7 @@ pub type SchedulerId = usize;
 /// If a fiber is in runnable state (e.g., not waiting for I/O events),
 /// the scheduler will push the fiber in it's run queue.
 /// When `run_once` method is called, the first fiber (i.e., future) in the queue
-/// will be poped and executed (i.e., `Future::poll` method is called).
+/// will be popped and executed (i.e., `Future::poll` method is called).
 /// If the future of a fiber moves to readied state,
 /// it will be removed from the scheduler.
 
@@ -236,7 +236,7 @@ pub struct Context<'a> {
     fiber: &'a mut FiberState,
 }
 impl<'a> Context<'a> {
-    /// Returns the identifier of the current exeuction context.
+    /// Returns the identifier of the current execution context.
     pub fn context_id(&self) -> super::ContextId {
         (self.scheduler.id, self.fiber.fiber_id)
     }

--- a/src/io/poll/mod.rs
+++ b/src/io/poll/mod.rs
@@ -31,7 +31,7 @@ where
     }
     pub fn lock(&self) -> EventedLock<T> {
         loop {
-            // NOTE: We assumes conflictions are very rare.
+            // NOTE: We assume conflicts are very rare.
             // (But should be refined in future releases)
             if let Some(inner) = self.0.try_borrow_mut() {
                 return EventedLock(inner);

--- a/src/io/poll/poller.rs
+++ b/src/io/poll/poller.rs
@@ -301,9 +301,9 @@ impl CancelTimeout {
 
 /// A future which will expire at the specified time instant.
 ///
-/// If this object is dropped before expiration, the timer will be cancelled.
-/// Thus, for example, the repetation of setting and canceling of
-/// a timer only consumpts constant memory region.
+/// If this object is dropped before expiration, the timer will be canceled.
+/// Thus, for example, the repetition of setting and canceling of
+/// a timer only consumes constant memory region.
 #[derive(Debug)]
 pub struct Timeout {
     cancel: Option<CancelTimeout>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -102,7 +102,7 @@
 //! let monitor = executor.spawn_monitor(future);
 //! let answer = executor.run_fiber(monitor).unwrap();
 //!
-//! // Checkes the answer.
+//! // Checks the answer.
 //! assert_eq!(answer, Ok(55));
 //! ```
 //!
@@ -138,7 +138,7 @@
 //!             // Spawns a fiber to handle the client.
 //!             handle0.spawn(client.and_then(move |client| {
 //!                     // For simplicity, splits reading process and
-//!                     // writing process into differrent fibers.
+//!                     // writing process into different fibers.
 //!                     let (reader, writer) = (client.clone(), client);
 //!                     let (tx, rx) = fibers::sync::mpsc::channel();
 //!

--- a/src/sync/mpsc.rs
+++ b/src/sync/mpsc.rs
@@ -141,7 +141,7 @@ pub fn sync_channel<T>(bound: usize) -> (SyncSender<T>, Receiver<T>) {
 
 /// The receiving-half of a mpsc channel.
 ///
-/// This receving stream will never fail.
+/// This receiving stream will never fail.
 ///
 /// This structure can be used on both inside and outside of a fiber.
 pub struct Receiver<T> {

--- a/src/sync/oneshot.rs
+++ b/src/sync/oneshot.rs
@@ -164,7 +164,7 @@ impl<T> fmt::Debug for Receiver<T> {
 ///
 /// // Spawns monitored fiber
 /// // (In practice, spawning fiber via `spawn_monitor` function is
-/// //  more convenient way to archieve the same result)
+/// //  more convenient way to achieve the same result)
 /// executor.spawn_fn(move || {
 ///     // Notifies the execution have completed successfully.
 ///     monitored.exit(Ok("succeeded") as Result<_, ()>);
@@ -199,7 +199,7 @@ impl<T> fmt::Debug for Receiver<T> {
 ///
 /// // Spawns monitored fiber
 /// // (In practice, spawning fiber via `spawn_monitor` function is
-/// //  more convenient way to archieve the same result)
+/// //  more convenient way to achieve the same result)
 /// executor.spawn_fn(move || {
 ///     let _ = monitored; // This fiber owns `monitored`
 ///     Ok(()) // Terminated before calling `Monitored::exit` method

--- a/src/time.rs
+++ b/src/time.rs
@@ -47,9 +47,9 @@ pub mod timer {
 
     /// A future which will expire at the specified time instant.
     ///
-    /// If this object is dropped before expiration, the timer will be cancelled.
-    /// Thus, for example, the repetation of setting and canceling of
-    /// a timer only consumpts constant memory region.
+    /// If this object is dropped before expiration, the timer will be canceled.
+    /// Thus, for example, the repetition of setting and canceling of
+    /// a timer only consumes constant memory region.
     #[derive(Debug)]
     pub struct Timeout {
         start: time::Instant,


### PR DESCRIPTION
There are a few things to note about this commit:

First, the corrections use American English spellings.  This affects things like 'cancelled' (British) vs. 'canceled' (American).  I don't know which dictionary is being used by the project to catch spelling errors, so you may wish to revert those changes.

Second, there are words in use like 'deschedule' that aren't actually in the English language or any of its dialects.  However, there is no better word than that, so even if your dictionary flags it in the future, I'd suggest that you keep using it (the word makes sense to native English speakers).

Finally, there are a few grammar errors that I've avoided changing as they are not spelling errors, and therefore outside of the scope of this commit.